### PR TITLE
Make Boost vars cached

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,8 @@ endif ()
 
 option (Boost_USE_STATIC_LIBS "Use static libraries for boost" ON)
 
-set (Boost_NO_SYSTEM_PATHS ON)
-set (Boost_USE_MULTITHREADED ON)
+set (Boost_NO_SYSTEM_PATHS CACHE BOOL ON)
+set (Boost_USE_MULTITHREADED CACHE BOOL ON)
 
 unset (Boost_INCLUDE_DIR CACHE)
 unset (Boost_LIBRARY_DIRS CACHE)


### PR DESCRIPTION
This line overwrites `Boost_NO_SYSTEM_PATHS` variable:
```
set(Boost_NO_SYSTEM_PATHS ON)
```
IMO it is not flexible and too strict.

Caching as below
```
set (Boost_NO_SYSTEM_PATHS CACHE BOOL ON)
```

allows users to overwrite this variable during cmake time:
```bash
$ cmake .. -DBoost_NO_SYSTEM_PATHS=OFF
```

